### PR TITLE
Make ambient optional in Material schema

### DIFF
--- a/src/openalea/lpy/parameters/schema/material.json
+++ b/src/openalea/lpy/parameters/schema/material.json
@@ -43,7 +43,6 @@
             "maximum": 1
         }
     },
-    "required": ["name", "index", "type", "ambient"],
+    "required": ["name", "index", "type"],
     "additionalProperties": false
 }
-


### PR DESCRIPTION
This will fix #22 

Apparently ambient is not added to the json_rep when it is equal to the default value. But since it is required in the schema the validation will fail. 