### PR TITLE
reset editor when closing the window. fix #30

### DIFF
--- a/src/openalea/lpy/gui/objectdialog.py
+++ b/src/openalea/lpy/gui/objectdialog.py
@@ -9,7 +9,7 @@ from openalea.plantgl.gui.qt import qt
 from openalea.plantgl.gui.qt.QtCore import QObject, pyqtSignal
 from openalea.plantgl.gui.qt.QtWidgets import QApplication, QCheckBox, QDialog, QHBoxLayout, QLayout, QMenuBar, QPushButton, QSizePolicy, QSpacerItem, QVBoxLayout
 
-    
+
 class ObjectDialog(QDialog):
     """the class that will create dialog between the panel and the editor window"""
     valueChanged = pyqtSignal()
@@ -25,7 +25,9 @@ class ObjectDialog(QDialog):
     
     def setupUi(self,editor):
         self.setObjectName("ObjectDialog")
-        self.resize(389, 282)
+        self.setBaseSize(600,400)
+        self.setMinimumHeight(200)
+        self.setMinimumWidth(300)
         self.verticalLayout = QVBoxLayout(self)
         self.verticalLayout.setSpacing(2)
         self.verticalLayout.setContentsMargins(2, 2, 2, 2)
@@ -74,7 +76,7 @@ class ObjectDialog(QDialog):
         self.applyButton.pressed.connect(self.__apply)
         self.autoUpdateCheckBox.toggled.connect(self.setAutomaticUpdate)
         self.objectView.valueChanged.connect(self.__valueChanged)
-        
+
     def menu(self):
         return self._menu
     
@@ -106,7 +108,4 @@ class ObjectDialog(QDialog):
             if self.automaticUpdate and self.hasChanged :
                 self.__apply()
                 
-
-    def closeEvent(self,event):
-        QDialog.closeEvent(self,event)
 

--- a/src/openalea/lpy/gui/objectpanel.py
+++ b/src/openalea/lpy/gui/objectpanel.py
@@ -137,7 +137,7 @@ class ManagerDialogContainer (QObject):
 
     def endObjectEdition(self):
         if self.editor:
-            self.editorDialog.hide()
+           self.editorDialog.hide()
         
     def getEditedObject(self):
         """ used by panel. ask for object edition to start. Use getEditor and  setObjectToEditor """
@@ -147,6 +147,7 @@ class ManagerDialogContainer (QObject):
     def endEditionEvent(self):
         """ called when closing editor. """
         self.editedobjectid = None
+        self.editor = None
     
     def isVisible(self):
         """ Tell whether editor is visible """


### PR DESCRIPTION
Even though it deletes and re-creates the editor object, it's a simple enough fix for now. 
I also fixed the window size starting too small on macOS 11.4 (now it starts at a comfortable 600x400 with a strict minimum size of 300x200, so you don't get lost with a dialog you can't even see the content of)